### PR TITLE
Prepare for appium upgrade

### DIFF
--- a/Appium/Android/Maven/pom.xml
+++ b/Appium/Android/Maven/pom.xml
@@ -11,7 +11,7 @@
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>6.0.0</version>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/Appium/Android/Maven/pom.xml
+++ b/Appium/Android/Maven/pom.xml
@@ -11,7 +11,7 @@
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>5.0.4</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.appcenter</groupId>
             <artifactId>appium-test-extension</artifactId>
-            <version>1.0</version>
+            <version>1.5</version>
         </dependency>
 
     </dependencies>

--- a/Appium/Android/Maven/src/test/java/com/microsoft/altframeworktraining/StartAppTest.java
+++ b/Appium/Android/Maven/src/test/java/com/microsoft/altframeworktraining/StartAppTest.java
@@ -29,7 +29,7 @@ public class StartAppTest {
 
         capabilities.setCapability(MobileCapabilityType.PLATFORM_NAME, "android");
         capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, "foo");
-        capabilities.setCapability(MobileCapabilityType.APP, "[path to local repo]/Appium/Android/swiftnote.apk");
+        capabilities.setCapability(MobileCapabilityType.APP, "[path to local repo]/Appium/Android/swiftnotes.apk");
         capabilities.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, 7913);
         capabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, "uiautomator2");
 

--- a/Appium/iOS/Maven/pom.xml
+++ b/Appium/iOS/Maven/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>6.0.0</version>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/Appium/iOS/Maven/pom.xml
+++ b/Appium/iOS/Maven/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>5.0.4</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.microsoft.appcenter</groupId>
             <artifactId>appium-test-extension</artifactId>
-            <version>1.0</version>
+            <version>1.5</version>
         </dependency>
     </dependencies>
 

--- a/Appium/iOS/Maven/src/test/java/com/microsoft/altframeworktraining/StartIOSAppTest.java
+++ b/Appium/iOS/Maven/src/test/java/com/microsoft/altframeworktraining/StartIOSAppTest.java
@@ -38,7 +38,7 @@ public class StartIOSAppTest {
 
 //        4. Uncomment the lines for either the iOS simulator or iOS device below
 //        (Simulator) *Make sure to unzip the included file
-//        String appPath = "/Users/kentgreen/Projects/AppCenter-Test-Samples/Appium/iOS/UITestDemo.iOS.app";
+//        String appPath = "/Users/kentgreen/Projects/AppCenter-Test-Samples/Appium/iOS/UITestDemo.iOS.app.zip";
 //        capabilities.setCapability(MobileCapabilityType.APP, appPath);
 
 //        (Device)


### PR DESCRIPTION
The appium upgrade will need at least version `6.0.0` of the java client. Updated  to the latest appium-test-extension while I was at it :-)