### PR TITLE
DO NOT MERGE: An experiment in how to read Instrumentation from Xamarin app in Android

### DIFF
--- a/Xamarin.UITest/UITestDemo/Droid/MainActivity.cs
+++ b/Xamarin.UITest/UITestDemo/Droid/MainActivity.cs
@@ -7,6 +7,7 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+using Com.Microsoft.Appcenter.Utils;
 
 namespace UITestDemo.Droid
 {
@@ -22,12 +23,35 @@ namespace UITestDemo.Droid
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
 
-            LoadApplication(new App());
+            LoadApplication(new App(RunningInAppCenter()));
         }
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
         {
             base.OnActivityResult(requestCode, resultCode, data);
+        }
+
+        private bool RunningInAppCenter()
+        {
+            try
+            {
+                var arguments = InstrumentationRegistryHelper.Arguments;
+                var runningInAppCenter = arguments.GetString("RUNNING_IN_APP_CENTER");
+                if (runningInAppCenter == null || runningInAppCenter != "1")
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Java.Lang.LinkageError)
+            {
+                return false;
+            }
+            catch (Java.Lang.IllegalStateException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/Xamarin.UITest/UITestDemo/Droid/Properties/AndroidManifest.xml
+++ b/Xamarin.UITest/UITestDemo/Droid/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.UITestDemo">
-	<uses-sdk android:minSdkVersion="15" />
+	<uses-sdk android:minSdkVersion="19" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application android:label="UITestDemo"></application>
 </manifest>

--- a/Xamarin.UITest/UITestDemo/Droid/UITestDemo.Droid.csproj
+++ b/Xamarin.UITest/UITestDemo/Droid/UITestDemo.Droid.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Xamarin.Forms.3.6.0.344457\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.3.6.0.344457\build\Xamarin.Forms.props')" />
+  <Import Project="..\packages\Xamarin.Forms.4.0.0.425677\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.4.0.0.425677\build\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -113,21 +113,20 @@
       <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\packages\Xamarin.Forms.3.6.0.344457\lib\MonoAndroid90\FormsViewGroup.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.4.0.0.425677\lib\MonoAndroid90\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.3.6.0.344457\lib\MonoAndroid90\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.4.0.0.425677\lib\MonoAndroid90\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\packages\Xamarin.Forms.3.6.0.344457\lib\MonoAndroid90\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.4.0.0.425677\lib\MonoAndroid90\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.3.6.0.344457\lib\MonoAndroid90\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.4.0.0.425677\lib\MonoAndroid90\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.3.6.0.344457\lib\MonoAndroid90\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.4.0.0.425677\lib\MonoAndroid90\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
-    <Reference Include="Java.Interop" />
     <Reference Include="Xamarin.Android.Arch.Core.Runtime">
       <HintPath>..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Core.Runtime.dll</HintPath>
     </Reference>
@@ -187,6 +186,18 @@
     </Reference>
     <Reference Include="Xamarin.Android.Support.CustomTabs">
       <HintPath>..\packages\Xamarin.Android.Support.CustomTabs.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.CustomTabs.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Android.Bindings">
+      <HintPath>..\packages\Microsoft.AppCenter.2.0.0\lib\MonoAndroid403\Microsoft.AppCenter.Android.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter">
+      <HintPath>..\packages\Microsoft.AppCenter.2.0.0\lib\MonoAndroid403\Microsoft.AppCenter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Analytics.Android.Bindings">
+      <HintPath>..\packages\Microsoft.AppCenter.Analytics.2.0.0\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.Android.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Analytics">
+      <HintPath>..\packages\Microsoft.AppCenter.Analytics.2.0.0\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -251,5 +262,5 @@
   <Import Project="..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Design.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Design.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.targets')" />
-  <Import Project="..\packages\Xamarin.Forms.3.6.0.344457\build\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.3.6.0.344457\build\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.4.0.0.425677\build\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.4.0.0.425677\build\Xamarin.Forms.targets')" />
 </Project>

--- a/Xamarin.UITest/UITestDemo/Droid/packages.config
+++ b/Xamarin.UITest/UITestDemo/Droid/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AppCenter" version="2.0.0" targetFramework="monoandroid90" />
+  <package id="Microsoft.AppCenter.Analytics" version="2.0.0" targetFramework="monoandroid90" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="monoandroid71" />
   <package id="Xam.Plugin.Connectivity" version="3.0.2" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Arch.Core.Common" version="1.1.1.1" targetFramework="monoandroid90" />
@@ -41,5 +43,5 @@
   <package id="Xamarin.Android.Support.Vector.Drawable" version="28.0.0.1" targetFramework="monoandroid90" />
   <package id="Xamarin.Android.Support.VersionedParcelable" version="28.0.0.1" targetFramework="monoandroid90" />
   <package id="Xamarin.Android.Support.ViewPager" version="28.0.0.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Forms" version="3.6.0.344457" targetFramework="monoandroid90" />
+  <package id="Xamarin.Forms" version="4.0.0.425677" targetFramework="monoandroid90" />
 </packages>

--- a/Xamarin.UITest/UITestDemo/UITestDemo.UITest/Tests.cs
+++ b/Xamarin.UITest/UITestDemo/UITestDemo.UITest/Tests.cs
@@ -32,6 +32,13 @@ namespace UITestDemo.UITest
         }
 
         [Test]
+        public void AppEnvironment()
+        {
+            app.Screenshot("First screen.");
+            app.WaitForElement(x => x.Text("Running in App Center!"));
+        }
+
+        [Test]
         public void ClearTextDemo()
         {
             app.Tap(x => x.Marked("Add"));

--- a/Xamarin.UITest/UITestDemo/UITestDemo/App.xaml.cs
+++ b/Xamarin.UITest/UITestDemo/UITestDemo/App.xaml.cs
@@ -9,7 +9,7 @@ namespace UITestDemo
         public static bool UseMockDataStore = true;
         public static string BackendUrl = "https://localhost:5000";
 
-        public App()
+        public App(bool runningInAppCenter)
         {
             InitializeComponent();
 
@@ -19,9 +19,9 @@ namespace UITestDemo
                 DependencyService.Register<CloudDataStore>();
 
             if (Device.RuntimePlatform == Device.iOS)
-                MainPage = new MainPage();
+                MainPage = new MainPage(runningInAppCenter);
             else
-                MainPage = new NavigationPage(new MainPage());
+                MainPage = new NavigationPage(new MainPage(runningInAppCenter));
         }
     }
 }

--- a/Xamarin.UITest/UITestDemo/UITestDemo/Views/MainPage.cs
+++ b/Xamarin.UITest/UITestDemo/UITestDemo/Views/MainPage.cs
@@ -6,7 +6,7 @@ namespace UITestDemo
 {
     public class MainPage : TabbedPage
     {
-        public MainPage()
+        public MainPage(bool runningInAppCenter)
         {
             Page itemsPage, aboutPage = null;
 
@@ -41,7 +41,14 @@ namespace UITestDemo
             Children.Add(itemsPage);
             Children.Add(aboutPage);
 
-            Title = Children[0].Title;
+            if (runningInAppCenter)
+            {
+                Title = "Running in App Center!";
+            }
+            else
+            {
+                Title = "Running locally!";
+            }
         }
 
         protected override void OnCurrentPageChanged()


### PR DESCRIPTION
### Motivation

An attempt to answer the question "how can you tell if you're in App Center on Xamarin.Android".

Adds an example test for Android to show how we'd check for running in App Center in a Xamarin app.

### Notes

I utilised existing code written for the AppCenter SDK (`InstrumentationRegistryHelper`) - could we suggest that users simply reuse this code?

[Here it is working on a range of devices](https://appcenter.ms/orgs/Niblock-Org/apps/UITestDemo/test/runs/e73006db-9c4d-4dea-9389-198e24105fcd/0-0-0)

_DO NOT MERGE_ we'll have to fix iOS before merging this (if indeed we do want to merge it) we could just document what we've done here in the docs?